### PR TITLE
Py2 3 compatibility fix

### DIFF
--- a/tasks/install_package.yml
+++ b/tasks/install_package.yml
@@ -15,7 +15,7 @@
   apt: name={{python_package_name}} update_cache=yes cache_valid_time=86400
 
 - name: Get python version
-  shell: "apt-cache show {{python_package_name}} | grep 'Version:' | awk '{print $2}' | cut -d. -f1"
+  shell: "apt-cache policy {{python_package_name}} | grep 'Installed:' | awk '{print $2}' | cut -d. -f1"
   check_mode: no
   register: python_version_output
   changed_when: False #This just polls the system for information and doesn't change system information

--- a/tasks/install_pip.yml
+++ b/tasks/install_pip.yml
@@ -1,4 +1,8 @@
 ---
+- name: Install python3-distutils
+  package:
+    name: python3-distutils
+  when: ansible_distribution_release == 'bionic'
 
 - name: Download get-pip.py
   get_url: url=https://bootstrap.pypa.io/get-pip.py dest=/tmp/

--- a/templates/pip.conf.j2
+++ b/templates/pip.conf.j2
@@ -1,6 +1,6 @@
-{% for section,config in python_pip_config.iteritems() | sort %}
+{% for section,config in python_pip_config.items() | sort %}
 [{{section}}]
-{% for k,v in config.iteritems() | sort %}
+{% for k,v in config.items() | sort %}
 {% if v is iterable and v is not string %}
 {{k}} =
 {% for item in v %}


### PR DESCRIPTION
Changing iteritems to items in templates to make compatible with both Python 2 and 3 as per Ansible documentation: https://docs.ansible.com/ansible/latest/user_guide/playbooks_python_version.html

Ubuntu 18.04 python3 does not ship with distutils, so does not have the required libraries to install pip (https://github.com/pypa/pip/issues/5356)